### PR TITLE
v2: add `AbortWithError` shortcut function

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -34,10 +34,22 @@ app.Router.Use(gin.Recovery())
 apiGroup := app.Router.Group("/api")
 {
 	apiGroup.Use(middleware.BasicJWT("test-system-token"))
+        // a simple GET request handler
 	apiGroup.GET("/status", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"status": "up",
 			"redis":  "connected",
+		})
+	})
+        // request can be aborted with a helper function rebar.AbortWithError()
+	apiGroup.DELETE("/another_example", func(c *gin.Context) {
+		if c.Query("required_parameter") == "" {
+			rebar.AbortWithError(c, http.StatusBadRequest,
+				errors.New("required_parameter is not provided"))
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"some": "data",
 		})
 	})
 }
@@ -86,3 +98,149 @@ type Options struct {
 	StopOnProcessorStartFailure bool
 }
 ```
+
+### Upgrade from `v0` to `v2`
+
+<table>
+<tr>
+<th></th>
+<th>v0</th>
+<th>v2</th>
+</tr>
+<tr>
+<td>
+
+`main.go`
+
+</td>
+<td>
+
+```go
+func main() {
+	app := app.App()
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	err := app.Serve(c)
+	if err != nil {
+		panic(err)
+	}
+}
+```
+
+</td>
+<td>
+
+```go
+func main() {
+	ctx, stop := rebar.ContextWithCancel()
+	app := app.New(ctx, stop)
+	if err := app.RunWithContext(ctx, stop); err != nil {
+		log.Fatal("ERROR:", err)
+	}
+}
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`app/app.go`
+
+</td>
+<td>
+
+```go
+var app *service.Rebar
+
+func App() *service.Rebar {
+	if app == nil {
+		app = service.New(service.Options{
+			Environment: "development",
+			Port:        "3005",
+		})
+		apiSubRouter.Use(middleware.Logger)
+		apiSubRouter.HandleFunc("/status", api.Status())
+	}
+	return app
+}
+```
+
+</td>
+<td>
+
+```go
+func New(ctx context.Context, stop context.CancelFunc) *rebar.Rebar {
+	logger, err := rebar.NewStandardLogger()
+	if err != nil {
+		log.Fatal("ERROR:", err)
+	}
+	app := rebar.New(rebar.Options{
+		Environment: rebar.Development,
+		Port:        "3000",
+		Logger:      logger,
+	})
+	app.Router.Use(middleware.Logger(logger))
+	app.Router.Use(middleware.Recovery())
+	app.Router.GET("/status", api.Status())
+	return app
+}
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`api/status.go`
+
+</td>
+<td>
+
+```go
+func Status() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		type status struct {
+			Status string `json:"status"`
+			Redis  string `json:"redis"`
+			Uptime string `json:"uptime"`
+		}
+
+		s := status{
+			Status: func() string {
+				return "up"
+			}(),
+			Redis: func() string {
+				return "connected"
+			}(),
+			Uptime: time.Since(appStartTime).Truncate(time.Second).String(),
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(s)
+	}
+}
+```
+
+</td>
+<td>
+
+```go
+func Status() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"status": "up",
+			"redis":  "connected",
+			"uptime": time.Since(appStartTime).Truncate(time.Second).String(),
+		})
+	}
+}
+```
+
+</td>
+</tr>
+</table>
+
+Another example for [gracefully shutting down worker for long running goroutines](./examples/graceful).

--- a/v2/context.go
+++ b/v2/context.go
@@ -1,0 +1,31 @@
+package rebar
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	I18nKey      = "i18n"
+	LoggerKey    = "rebarLogger"
+	RequestIDKey = "requestID"
+	TxKey        = "tx"
+)
+
+type BuffaloValidateError interface {
+	Error() string
+	String() string
+	HasAny() bool
+}
+
+func AbortWithError(c *gin.Context, code int, err error) *gin.Error {
+	hashmap := gin.H{
+		"request_id": RequestIDFrom(c),
+	}
+	if _, ok := err.(BuffaloValidateError); ok {
+		hashmap["validate"] = err
+	} else {
+		hashmap["error"] = err.Error()
+	}
+	c.AbortWithStatusJSON(code, hashmap)
+	return c.Error(err)
+}

--- a/v2/context_test.go
+++ b/v2/context_test.go
@@ -1,0 +1,66 @@
+package rebar_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/masonhubco/rebar/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testBuffaloValidateError struct {
+	Errors                     map[string][]string `json:"errors"`
+	rebar.BuffaloValidateError `json:"-"`
+}
+
+func newTestBuffaloVlidateError() error {
+	return &testBuffaloValidateError{
+		Errors: map[string][]string{
+			"input_field": {"cannot be left blank"},
+		},
+	}
+}
+
+func Test_AbortWithError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		givenCode int
+		givenErr  error
+		wantBody  string
+	}{
+		{
+			name:      "with buffalo validate error",
+			givenCode: http.StatusBadRequest,
+			givenErr:  newTestBuffaloVlidateError(),
+			wantBody:  `{"request_id":"test-request-id","validate":{"errors":{"input_field":["cannot be left blank"]}}}`,
+		},
+		{
+			name:      "with just an error",
+			givenCode: http.StatusTeapot,
+			givenErr:  errors.New("expected unit test error"),
+			wantBody:  `{"request_id":"test-request-id","error":"expected unit test error"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(resp)
+			ctx.Set(rebar.RequestIDKey, "test-request-id")
+
+			rebar.AbortWithError(ctx, tc.givenCode, tc.givenErr)
+
+			require.Equal(t, tc.givenCode, resp.Code)
+			assert.JSONEq(t, tc.wantBody, resp.Body.String())
+		})
+	}
+}

--- a/v2/logger.go
+++ b/v2/logger.go
@@ -6,11 +6,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const (
-	LoggerKey    = "rebarLogger"
-	RequestIDKey = "requestID"
-)
-
 type Logger interface {
 	Debug(msg string, fields ...zap.Field)
 	Error(msg string, fields ...zap.Field)


### PR DESCRIPTION
- include `request_id` in response JSON body
- add error to gin context
- detect and handle buffalo validate error